### PR TITLE
主キーをページネーションしながらupdateする

### DIFF
--- a/dbtestdata.pl
+++ b/dbtestdata.pl
@@ -154,7 +154,6 @@
       my $count = 0;
       while ($cursor <= $primaryKeysCount[0]) {
         my $sql = sprintf("SELECT %s FROM %s LIMIT %s OFFSET %s", $conf->{'primary'}, $table, $PULSE_COMMIT, $cursor);
-        STDOUT->print("\r$sql");
         $sth = $db->prepare($sql) || die $DBI::error;
         $sth->execute() || die $DBI::error;
         

--- a/dbtestdata.pl
+++ b/dbtestdata.pl
@@ -151,6 +151,7 @@
       STDOUT->print("\r$primaryKeysCount[0] records will update.");
 
       my $cursor = 0;
+      my $count = 0;
       while ($cursor <= $primaryKeysCount[0]) {
         my $sql = sprintf("SELECT %s FROM %s LIMIT %s OFFSET %s", $conf->{'primary'}, $table, $PULSE_COMMIT, $cursor);
         STDOUT->print("\r$sql");
@@ -162,7 +163,7 @@
           push(@primaryKeys, $row->[0]);
         }
         
-        my $count = 0;
+        $count = 0;
         foreach my $pk (@primaryKeys) {
           $count++;
           

--- a/dbtestdata.pl
+++ b/dbtestdata.pl
@@ -150,32 +150,38 @@
       }
       STDOUT->print("\r$primaryKeysCount[0] records will update.");
 
-      my $sql = sprintf("SELECT %s FROM %s", $conf->{'primary'}, $table);
-      $sth = $db->prepare($sql) || die $DBI::error;
-      $sth->execute() || die $DBI::error;
-      
-      my @primaryKeys;
-      while (my $row = $sth->fetchrow_arrayref()) {
-        push(@primaryKeys, $row->[0]);
-      }
-      
-      my $count = 0;
-      foreach my $pk (@primaryKeys) {
-        $count++;
+      my $cursor = 0;
+      while ($cursor <= $primaryKeysCount[0]) {
+        my $sql = sprintf("SELECT %s FROM %s LIMIT %s OFFSET %s", $conf->{'primary'}, $table, $PULSE_COMMIT, $cursor);
+        STDOUT->print("\r$sql");
+        $sth = $db->prepare($sql) || die $DBI::error;
+        $sth->execute() || die $DBI::error;
         
-        $db->do(
-          UPDATE_SQL(
-            $table,
-            (ref($conf->{'clazz'}) eq 'CODE') ? $conf->{'clazz'}->($pk) : $conf->{'clazz'},
-            [ WHERE($conf->{'primary'}, $pk) ]
-          )
-        ) || die $DBI::error;
-        
-        if (! ($count % $PULSE_COMMIT)) {
-          my $bar = $count % ($PULSE_COMMIT*2) ? '|' : '-';
-          $db->commit() || die $DBI::error;
-          STDOUT->print("\r$bar $count commited.");
+        my @primaryKeys;
+        while (my $row = $sth->fetchrow_arrayref()) {
+          push(@primaryKeys, $row->[0]);
         }
+        
+        my $count = 0;
+        foreach my $pk (@primaryKeys) {
+          $count++;
+          
+          $db->do(
+            UPDATE_SQL(
+              $table,
+              (ref($conf->{'clazz'}) eq 'CODE') ? $conf->{'clazz'}->($pk) : $conf->{'clazz'},
+              [ WHERE($conf->{'primary'}, $pk) ]
+            )
+          ) || die $DBI::error;
+          
+          if (! ($count % $PULSE_COMMIT)) {
+            my $bar = $count % ($PULSE_COMMIT*2) ? '|' : '-';
+            $db->commit() || die $DBI::error;
+            STDOUT->print("\r$bar $count commited.");
+          }
+        }
+
+        $cursor += $PULSE_COMMIT;
       }
       
       $db->commit() || die $DBI::error;

--- a/dbtestdata.pl
+++ b/dbtestdata.pl
@@ -148,7 +148,7 @@
       while (my $row = $sth->fetchrow_arrayref()) {
         push(@primaryKeysCount, $row->[0]);
       }
-      STDOUT->print("\r$bar $primaryKeysCount[0] records will update.");
+      STDOUT->print("\r$primaryKeysCount[0] records will update.");
 
       my $sql = sprintf("SELECT %s FROM %s", $conf->{'primary'}, $table);
       $sth = $db->prepare($sql) || die $DBI::error;

--- a/dbtestdata.pl
+++ b/dbtestdata.pl
@@ -151,7 +151,7 @@
       STDOUT->print("\r$bar $primaryKeysCount[0] records will update.");
 
       my $sql = sprintf("SELECT %s FROM %s", $conf->{'primary'}, $table);
-      my $sth = $db->prepare($sql) || die $DBI::error;
+      $sth = $db->prepare($sql) || die $DBI::error;
       $sth->execute() || die $DBI::error;
       
       my @primaryKeys;

--- a/dbtestdata.pl
+++ b/dbtestdata.pl
@@ -141,6 +141,15 @@
     while (my($table, $conf) = each(%$confUpdate)) {
       STDOUT->print("UPDATE $table\n");
       
+      my $sql_count = sprintf("SELECT count(%s) FROM %s", $conf->{'primary'}, $table);
+      my $sth = $db->prepare($sql_count) || die $DBI::error;
+      $sth->execute() || die $DBI::error;
+      my @primaryKeysCount;
+      while (my $row = $sth->fetchrow_arrayref()) {
+        push(@primaryKeysCount, $row->[0]);
+      }
+      STDOUT->print("\r$bar $primaryKeysCount[0] records will update.");
+
       my $sql = sprintf("SELECT %s FROM %s", $conf->{'primary'}, $table);
       my $sth = $db->prepare($sql) || die $DBI::error;
       $sth->execute() || die $DBI::error;

--- a/sql/VariableSQLGenerator.pm
+++ b/sql/VariableSQLGenerator.pm
@@ -59,9 +59,9 @@
         while (my($n,$v) = each(%$dataClazz)) {
             $v = _lbox($v);
             if ($v->{'type'} eq 'SQL') {
-                push(@dataValues, "$n=".$v->{'gen'}->());
+                push(@dataValues, "\`$n\`=".$v->{'gen'}->());
             } else {
-                push(@dataValues, "$n="._sqlquote($v->{'gen'}->()));
+                push(@dataValues, "\`$n\`="._sqlquote($v->{'gen'}->()));
             }
         }
         


### PR DESCRIPTION
# WHAT

主キーを全部配列に取ってくるため、テーブル件数と、実行環境のメモリ容量の組み合わせによっては、実行することができない事象に対処する。

# HOW

* select count(pk) from ....
* $PULSE_COMMIT ずつ pk をページネーションしながら、これまでどおりのループを回す

# WHY

subの中で階層を深くしたことは、深く反省している