### PR TITLE
発行されるSQL内のテーブル名をエスケープする

### DIFF
--- a/dbtestdata.pl
+++ b/dbtestdata.pl
@@ -102,6 +102,7 @@
     my $confInsert = $config->{'insert'};
     
     while (my($table, $conf) = each(%$confInsert)) {
+      $table = "`$table`";
       STDOUT->print("INSERT $table\n");
       
       my $count = 0;
@@ -140,6 +141,7 @@
     my $confUpdate = $config->{'update'};
     
     while (my($table, $conf) = each(%$confUpdate)) {
+      $table = "`$table`";
       STDOUT->print("UPDATE $table\n");
       
       my $sql_count = sprintf("SELECT ifnull(max(%s), 0) FROM %s", $conf->{'primary'}, $table);
@@ -201,6 +203,7 @@
     my $confDelete = $config->{'delete'};
     
     foreach my $t (@$confDelete) {
+      $t = "`$t`";
       STDOUT->print("DELETE $t\n");
       $db->do("DELETE FROM $t") || die $DBI::error;
       STDOUT->print("finished.\n");


### PR DESCRIPTION
## 概要
MySQL5.7からMySQL8.0にアップグレードすると多くの予約語が追加される（[参考](https://dev.mysql.com/doc/refman/8.0/ja/keywords.html#:~:text=8.0.22%20(%E4%BA%88%E7%B4%84%E3%81%AA%E3%81%97)-,MySQL%208.0%20%E3%81%AE%E6%96%B0%E3%81%97%E3%81%84%E3%82%AD%E3%83%BC%E3%83%AF%E3%83%BC%E3%83%89%E3%81%8A%E3%82%88%E3%81%B3%E4%BA%88%E7%B4%84%E8%AA%9E,-%E6%AC%A1%E3%81%AE%E3%83%AA%E3%82%B9%E3%83%88)）
これによって、既にあるテーブルの名前がうっかり予約語に該当してしまう事象が起こりうる
そのような場合、テーブル名がエスケープ処理されていなければsyntaxエラーとなってしまう。

予約語に該当するテーブル名がエスケープ処理がなされていないとき、例えば以下のようなエラーが出る

```sql
--エスケープしてる場合
mysql> select * from `member` ;
...
1 row in set (0.01 sec)

--エスケープしてない場合
mysql> select * from member ;
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'member' at line 1
```

そのため如何なるテーブル名が来ても正常にSQLが発行されるように、テーブル名をエスケープする処理を追加した。

## 確認
次のような構成のconfigに対して以下を実行して、各標準出力されたSQLにエスケープ処理が追加されてることを確認した
```perl
my $config = {
    name => '__PACKAGE__',
    update => {
        test => {
            primary => 'id',
            clazz => {
                name => 'SQL(CONCAT("updated", id))'
            }
        }
    }
};
my $confUpdate = $config->{'update'};
while (my($table, $conf) = each(%$confUpdate)) {
      $table = "`$table`";
      STDOUT->print("UPDATE $table\n");
      my $sql_count = sprintf("SELECT ifnull(max(%s), 0) FROM %s", $conf->{'primary'}, $table);
      STDOUT->print("$sql_count\n");
};

```

